### PR TITLE
Improve crashing on startup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
     adafruit/DHT sensor library@^1.4.3
     https://github.com/tzapu/WiFiManager.git#2.0.5-beta
 	256dpi/MQTT@^2.5.0
-    https://github.com/kivancsikert/farmhub-client.git#0.10.0
+    https://github.com/kivancsikert/farmhub-client.git#0.10.1
 platform = espressif32
 board = esp32dev
 board_build.partitions = partitions.csv

--- a/src/MeterHandler.hpp
+++ b/src/MeterHandler.hpp
@@ -9,10 +9,12 @@
 using namespace std::chrono;
 using namespace farmhub::client;
 
-FlowMeter* __meterInstance;
+FlowMeter* __meterInstance = nullptr;
 
 IRAM_ATTR void __meterHandlerCountCallback() {
-    __meterInstance->count();
+    if (__meterInstance != nullptr) {
+        __meterInstance->count();
+    }
 }
 
 class MeterHandler
@@ -41,8 +43,10 @@ public:
     void begin(gpio_num_t flowPin) {
         this->flowPin = flowPin;
 
+        noInterrupts();
         meter = new FlowMeter(digitalPinToInterrupt(flowPin), UncalibratedSensor, __meterHandlerCountCallback, RISING);
         __meterInstance = meter;
+        interrupts();
 
         auto now = boot_clock::now();
         lastMeasurement = now;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ public:
 protected:
     void onWake(WakeEvent& event) override {
         // Turn led on when we start
+        Serial.printf("Woken by source: %d\n", event.source);
         pinMode(LED_PIN, OUTPUT);
         digitalWrite(LED_PIN, HIGH);
     }


### PR DESCRIPTION
Improves #18 to some degree: we still seem to crash without USB being connected on startup sometimes, but at least we get out of that state in a couple of restarts. This is good enough for now.

For a full fix our best course of action might be to re-implement the flow handling using ESP32's PCNT (see #1). 

This PR also fixes the LED state by upgrading to https://github.com/kivancsikert/farmhub-client/releases/tag/0.10.1.