### PR TITLE
Use ESP32 PCNT to measure flow

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,6 @@ extra_scripts =
     pre:git-version.py
 build_type = debug
 lib_deps =
-    sekdiy/FlowMeter@^1.2.0
 	bblanchon/ArduinoJson@^6.18.3
     adafruit/Adafruit Unified Sensor@^1.1.4
     adafruit/DHT sensor library@^1.4.3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@ class FlowMeterDeviceConfig : public Application::DeviceConfiguration {
 public:
     FlowMeterDeviceConfig()
         : Application::DeviceConfiguration("flow-control", "mk1") {
-
     }
 
     uint8_t getDhtType() {
@@ -87,7 +86,7 @@ public:
 
 protected:
     void beginApp() override {
-        flowMeter.begin(FLOW_PIN);
+        flowMeter.begin(FLOW_PIN, 5.0f);
         valve.begin(VALVE_OPEN_PIN, VALVE_CLOSE_PIN);
         mode.begin(MODE_OPEN_PIN, MODE_AUTO_PIN, MODE_CLOSE_PIN);
         environment.begin(DHT_PIN, deviceConfig.getDhtType());


### PR DESCRIPTION
Fixes #1.

Instead of the interrupt-based FlowMeter library.

See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/pcnt.html.