### PR TITLE
Upgrade to Espressif32 platform 4.2.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,10 @@ default_envs = esp32
 
 [env:esp32]
 monitor_speed = 115200
+platform = espressif32@^4.2.0
 framework = arduino
+board = esp32dev
+board_build.partitions = partitions.csv
 extra_scripts =
     pre:git-version.py
 build_type = debug
@@ -22,18 +25,15 @@ lib_deps =
 	beegee-tokyo/DHT sensor library for ESPx@^1.18
     https://github.com/tzapu/WiFiManager.git#2.0.5-beta
 	256dpi/MQTT@^2.5.0
-    https://github.com/kivancsikert/farmhub-client.git#0.10.3
-platform = espressif32
-board = esp32dev
-board_build.partitions = partitions.csv
-monitor_filters = esp32_exception_decoder
-monitor_port = /dev/cu.wchusbserial*
-upload_port = /dev/cu.wchusbserial*
-upload_speed = 1500000
+    https://github.com/kivancsikert/farmhub-client.git#0.11.0
 build_flags =
     -DARDUINOJSON_USE_LONG_LONG=1
     -DDUMP_MQTT
     ;-DLOG_TASKS
+monitor_filters = esp32_exception_decoder
+monitor_port = /dev/cu.wchusbserial*
+upload_port = /dev/cu.wchusbserial*
+upload_speed = 1500000
 
 [env:native]
 platform = native


### PR DESCRIPTION
Upgrade to https://github.com/kivancsikert/farmhub-client/releases/tag/0.11.0 and https://github.com/espressif/arduino-esp32/releases/tag/2.0.2.