### PR TITLE
Revert back to Arduino 1.x

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,7 @@
 default_envs = esp32
 
 [env:esp32]
-monitor_speed = 115200
-platform = espressif32@^4.2.0
+platform = espressif32@~3.5.0
 framework = arduino
 board = esp32dev
 board_build.partitions = partitions.csv
@@ -25,13 +24,14 @@ lib_deps =
 	beegee-tokyo/DHT sensor library for ESPx@^1.18
     https://github.com/tzapu/WiFiManager.git#v2.0.11-beta
 	256dpi/MQTT@^2.5.0
-    https://github.com/kivancsikert/farmhub-client.git#0.12.2
+    https://github.com/kivancsikert/farmhub-client.git#0.12.3
 build_flags =
     -DARDUINOJSON_USE_LONG_LONG=1
     -DDUMP_MQTT
     ;-DLOG_TASKS
 monitor_filters = esp32_exception_decoder
 monitor_port = /dev/cu.wchusbserial*
+monitor_speed = 115200
 upload_port = /dev/cu.wchusbserial*
 upload_speed = 1500000
 

--- a/src/ValveHandler.hpp
+++ b/src/ValveHandler.hpp
@@ -25,8 +25,8 @@ public:
     };
 
     ValveHandler(MqttHandler& mqtt, EventHandler& events, milliseconds pulseDuration)
-        : pulseDuration(pulseDuration)
-        , events(events) {
+        : events(events)
+        , pulseDuration(pulseDuration) {
         mqtt.registerCommand("set-valve", [&](const JsonObject& request, JsonObject& response) {
             State state = request["state"].as<State>();
             Serial.println("Controlling valve to " + String(static_cast<int>(state)));


### PR DESCRIPTION
Problems with Arduino 2.x include a long time to connect to NTP and an SSL connection error when trying to HTTP update firmware form github.com.