### PR TITLE
Increase default hold current and switching duration for NC/NO valves

### DIFF
--- a/src/mk4/Drv8801ValveController.hpp
+++ b/src/mk4/Drv8801ValveController.hpp
@@ -24,8 +24,8 @@ public:
             : NamedConfigurationSection(parent, "valve") {
         }
 
-        Property<milliseconds> switchDuration { this, "switchDuration", milliseconds { 250 } };
-        Property<double> holdDuty { this, "holdDuty", 0.4 };
+        Property<milliseconds> switchDuration { this, "switchDuration", milliseconds { 500 } };
+        Property<double> holdDuty { this, "holdDuty", 0.5 };
     };
 
     Drv8801ValveController(const Config& config)


### PR DESCRIPTION
Switch at 100% for 0.5 sec (was 0.25 sec), and hold at 50% duty cycle (instead of 40%) by default.