### PR TITLE
Bump dependency versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -81,4 +81,4 @@ platform = native
 test_framework = googletest
 lib_deps =
     ${base.lib_deps}
-    google/googletest@~1.11.0
+    google/googletest@~1.12.1

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,7 +65,7 @@ lib_deps =
     ${esp32base.lib_deps}
     robtillaart/SHT31@~0.3.7
     # Must use OneWireNg because of issue #112 of OneWire
-    pstolarz/OneWireNg@~0.11.2
+    pstolarz/OneWireNg@~0.12.1
     milesburton/DallasTemperature@~3.9.1
 lib_ignore =
     OneWire

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ extra_scripts =
 build_type = debug
 lib_deps =
 	${base.lib_deps}
-    https://github.com/tzapu/WiFiManager.git#v2.0.11-beta
+    https://github.com/tzapu/WiFiManager.git#v2.0.14-beta
 	256dpi/MQTT@~2.5.0
     https://github.com/kivancsikert/farmhub-client.git#0.12.8
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,7 +63,7 @@ extends = esp32base, uart-cp2014
 board = esp32-s2-saola-1
 lib_deps =
     ${esp32base.lib_deps}
-    robtillaart/SHT31@~0.3.6
+    robtillaart/SHT31@~0.3.7
     # Must use OneWireNg because of issue #112 of OneWire
     pstolarz/OneWireNg@~0.11.2
     milesburton/DallasTemperature@~3.9.1


### PR DESCRIPTION
* WiFiManager to 2.0.14-beta
* SHT to 0.3.7
* OneWireNg to 0.12.1
* GoogleTest to 1.12.1