### PR TITLE
Do not retain 'init' message

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ lib_deps =
 	${base.lib_deps}
     https://github.com/tzapu/WiFiManager.git#v2.0.14-beta
 	256dpi/MQTT@~2.5.0
-    https://github.com/kivancsikert/farmhub-client.git#0.12.8
+    https://github.com/kivancsikert/farmhub-client.git#0.12.9
 build_flags =
     ${base.build_flags}
     -DDUMP_MQTT


### PR DESCRIPTION
Bumps farmhub-client to 0.12.9.

See https://github.com/kivancsikert/farmhub-client/pull/91