### PR TITLE
Use MAC address to identify the device

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,13 +13,13 @@ default_envs = mk4
 
 [base]
 lib_deps =
-	bblanchon/ArduinoJson@~6.19.4
+	bblanchon/ArduinoJson@~6.20.1
 build_flags =
     -DARDUINOJSON_USE_LONG_LONG=1
 
 [esp32base]
 extends = base
-platform = espressif32@~4.4.0
+platform = espressif32@~6.0.1
 framework = arduino
 board_build.partitions = partitions.csv
 extra_scripts =
@@ -27,9 +27,9 @@ extra_scripts =
 build_type = debug
 lib_deps =
 	${base.lib_deps}
-    https://github.com/tzapu/WiFiManager.git#v2.0.14-beta
+    https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
 	256dpi/MQTT@~2.5.0
-    https://github.com/kivancsikert/farmhub-client.git#0.12.9
+    https://github.com/kivancsikert/farmhub-client.git#0.13.1
 build_flags =
     ${base.build_flags}
     -DDUMP_MQTT
@@ -65,7 +65,7 @@ lib_deps =
     ${esp32base.lib_deps}
     robtillaart/SHT31@~0.3.7
     # Must use OneWireNg because of issue #112 of OneWire
-    pstolarz/OneWireNg@~0.12.1
+    pstolarz/OneWireNg@~0.13.0
     milesburton/DallasTemperature@~3.9.1
 lib_ignore =
     OneWire
@@ -81,4 +81,4 @@ platform = native
 test_framework = googletest
 lib_deps =
     ${base.lib_deps}
-    google/googletest@~1.12.1
+    google/googletest@~1.13.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -81,4 +81,4 @@ platform = native
 test_framework = googletest
 lib_deps =
     ${base.lib_deps}
-    google/googletest@~1.13.0
+    google/googletest@~1.12.1

--- a/src/AbstractFlowControlApp.hpp
+++ b/src/AbstractFlowControlApp.hpp
@@ -81,7 +81,7 @@ class AbstractFlowControlApp
 public:
     AbstractFlowControlApp(
         AbstractFlowControlDeviceConfig& deviceConfig, ValveController& valveController)
-        : Application("Flow control", VERSION, deviceConfig, config, wifiProvider)
+        : Application("flow-control", VERSION, deviceConfig, config, wifiProvider)
         , deviceConfig(deviceConfig)
         , valve(tasks, mqtt, events, valveController) {
         telemetryPublisher.registerProvider(flowMeter);


### PR DESCRIPTION
Specifically, we use it now to determine the MQTT topic. This allows dynamic mapping of device IDs to logical names on the server side, and makes it easier to bootstrap new devices, as they don't need a unique name to be set.