### PR TITLE
Fix not deactivating override when no schedule is set

### DIFF
--- a/src/ValveHandler.hpp
+++ b/src/ValveHandler.hpp
@@ -75,7 +75,8 @@ public:
 
         // RTC memory is reset to 0 upon power-up
         if (valveHandlerStoredState == 0) {
-            Serial.println("Initializing for the first time");
+            Serial.println("Initializing for the first time to default state");
+            setState(controller.getDefaultState());
         } else {
             Serial.println("Initializing after waking from sleep with state = " + String(valveHandlerStoredState));
             state = valveHandlerStoredState == 1

--- a/src/ValveHandler.hpp
+++ b/src/ValveHandler.hpp
@@ -12,11 +12,18 @@ using namespace farmhub::client;
 RTC_DATA_ATTR
 int8_t valveHandlerStoredState;
 
+enum class ValveState {
+    CLOSED = -1,
+    NONE = 0,
+    OPEN = 1
+};
+
 class ValveController {
 public:
     virtual void open() = 0;
     virtual void close() = 0;
     virtual void reset() = 0;
+    virtual ValveState getDefaultState() = 0;
 };
 
 /**
@@ -30,19 +37,13 @@ class ValveHandler
     : public TelemetryProvider,
       public BaseTask {
 public:
-    enum class State {
-        CLOSED = -1,
-        NONE = 0,
-        OPEN = 1
-    };
-
     ValveHandler(TaskContainer& tasks, MqttHandler& mqtt, EventHandler& events, ValveController& controller)
         : BaseTask(tasks, "ValveHandler")
         , events(events)
         , controller(controller) {
         mqtt.registerCommand("override", [&](const JsonObject& request, JsonObject& response) {
-            State targetState = request["state"].as<State>();
-            if (targetState == State::NONE) {
+            ValveState targetState = request["state"].as<ValveState>();
+            if (targetState == ValveState::NONE) {
                 resume();
             } else {
                 seconds duration = request.containsKey("duration")
@@ -78,8 +79,8 @@ public:
         } else {
             Serial.println("Initializing after waking from sleep with state = " + String(valveHandlerStoredState));
             state = valveHandlerStoredState == 1
-                ? State::OPEN
-                : State::CLOSED;
+                ? ValveState::OPEN
+                : ValveState::CLOSED;
         }
         enabled = true;
     }
@@ -99,7 +100,7 @@ public:
         }
     }
 
-    void override(State state, seconds duration) {
+    void override(ValveState state, seconds duration) {
         Serial.printf("Overriding valve to %d for %d seconds\n", static_cast<int>(state), duration.count());
         manualOverrideEnd = system_clock::now() + duration;
         setState(state);
@@ -108,49 +109,52 @@ public:
     void resume() {
         Serial.println("Normal valve operation resumed");
         manualOverrideEnd = time_point<system_clock>();
+        auto defaultState = controller.getDefaultState();
     }
 
 protected:
     const Schedule loop(const Timing& timing) override {
-        if (!enabled || schedules.empty()) {
+        if (!enabled) {
             return sleepIndefinitely();
         }
 
-        if (manualOverrideEnd < system_clock::now()) {
-            if (manualOverrideEnd != time_point<system_clock>()) {
-                resume();
-            }
+        auto now = system_clock::now();
+        auto targetState = state;
 
-            auto targetState = scheduler.isScheduled(schedules, system_clock::now())
-                ? State::OPEN
-                : State::CLOSED;
-
-            if (state != targetState) {
-                switch (targetState) {
-                    case State::OPEN:
-                        Serial.println("Opening on schedule");
-                        break;
-                    case State::CLOSED:
-                        Serial.println("Closing on schedule");
-                        break;
-                }
-                setState(targetState);
+        if (manualOverrideEnd != time_point<system_clock>()) {
+            if (manualOverrideEnd >= now) {
+                Serial.println("Manual override active");
+                return sleepFor(seconds { 1 });
             }
+            Serial.println("Manual override expired");
+            resume();
+            targetState = controller.getDefaultState();
+        }
+
+        if (!schedules.empty()) {
+            targetState = scheduler.isScheduled(schedules, now)
+                ? ValveState::OPEN
+                : ValveState::CLOSED;
+        }
+
+        if (state != targetState) {
+            Serial.println("Changing state");
+            setState(targetState);
         }
 
         return sleepFor(seconds { 1 });
     }
 
 private:
-    void setState(State state) {
+    void setState(ValveState state) {
         this->state = state;
         switch (state) {
-            case State::OPEN:
+            case ValveState::OPEN:
                 Serial.println("Opening");
                 valveHandlerStoredState = 1;
                 controller.open();
                 break;
-            case State::CLOSED:
+            case ValveState::CLOSED:
                 Serial.println("Closing");
                 valveHandlerStoredState = -1;
                 controller.close();
@@ -165,15 +169,15 @@ private:
     EventHandler& events;
     ValveController& controller;
 
-    State state = State::NONE;
+    ValveState state = ValveState::NONE;
     time_point<system_clock> manualOverrideEnd;
     bool enabled = false;
     std::list<ValveSchedule> schedules;
 };
 
-bool convertToJson(const ValveHandler::State& src, JsonVariant dst) {
+bool convertToJson(const ValveState& src, JsonVariant dst) {
     return dst.set(static_cast<int>(src));
 }
-void convertFromJson(JsonVariantConst src, ValveHandler::State& dst) {
-    dst = static_cast<ValveHandler::State>(src.as<int>());
+void convertFromJson(JsonVariantConst src, ValveState& dst) {
+    dst = static_cast<ValveState>(src.as<int>());
 }

--- a/src/mk3/ModeHandler.hpp
+++ b/src/mk3/ModeHandler.hpp
@@ -111,10 +111,10 @@ private:
             mode = currentMode;
             switch (mode) {
                 case Mode::OPEN:
-                    valveHandler.override(ValveHandler::State::OPEN, hours { 100 * 365 * 24 });
+                    valveHandler.override(ValveState::OPEN, hours { 100 * 365 * 24 });
                     break;
                 case Mode::CLOSED:
-                    valveHandler.override(ValveHandler::State::CLOSED, hours { 100 * 365 * 24 });
+                    valveHandler.override(ValveState::CLOSED, hours { 100 * 365 * 24 });
                     break;
                 case Mode::AUTO:
                     // Do nothing, it will be handled by the valve handler

--- a/src/mk3/RelayValveController.hpp
+++ b/src/mk3/RelayValveController.hpp
@@ -36,6 +36,10 @@ protected:
         reset();
     }
 
+    ValveState getDefaultState() override {
+        return ValveState::NONE;
+    }
+
     void reset() override {
         digitalWrite(openPin, HIGH);
         digitalWrite(closePin, HIGH);

--- a/src/mk4/Drv8801ValveController.hpp
+++ b/src/mk4/Drv8801ValveController.hpp
@@ -17,6 +17,8 @@ class ValveControlStrategy {
 public:
     virtual void open() = 0;
     virtual void close() = 0;
+    virtual ValveState getDefaultState() = 0;
+
     virtual String describe() = 0;
 };
 
@@ -74,9 +76,15 @@ public:
         void open() override {
             driveAndHold(HIGH);
         }
+
         void close() override {
             controller.stop();
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::CLOSED;
+        }
+
         String describe() override {
             return "normally closed with switch duration " + String((int) switchDuration.count()) + "ms and hold duty " + String(holdDuty * 100) + "%";
         }
@@ -92,9 +100,15 @@ public:
         void open() override {
             controller.stop();
         }
+
         void close() override {
             driveAndHold(LOW);
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::OPEN;
+        }
+
         String describe() override {
             return "normally open with switch duration " + String((int) switchDuration.count()) + "ms and hold duty " + String(holdDuty * 100) + "%";
         }
@@ -113,11 +127,17 @@ public:
             delay(switchDuration.count());
             controller.stop();
         }
+
         void close() override {
             controller.drive(LOW, 1.0);
             delay(switchDuration.count());
             controller.stop();
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::NONE;
+        }
+
         String describe() override {
             return "latching with switch duration " + String((int) switchDuration.count()) + "ms";
         }
@@ -173,6 +193,10 @@ public:
 
     void close() override {
         strategy->close();
+    }
+
+    ValveState getDefaultState() override {
+        return strategy->getDefaultState();
     }
 
     void reset() override {

--- a/src/mk5/Drv8874ValveController.hpp
+++ b/src/mk5/Drv8874ValveController.hpp
@@ -17,6 +17,8 @@ class ValveControlStrategy {
 public:
     virtual void open() = 0;
     virtual void close() = 0;
+    virtual ValveState getDefaultState() = 0;
+
     virtual String describe() = 0;
 };
 
@@ -75,9 +77,15 @@ public:
         void open() override {
             driveAndHold(HIGH);
         }
+
         void close() override {
             controller.stop();
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::CLOSED;
+        }
+
         String describe() override {
             return "normally closed with switch duration " + String((int) switchDuration.count()) + "ms and hold duty " + String(holdDuty * 100) + "%";
         }
@@ -93,9 +101,15 @@ public:
         void open() override {
             controller.stop();
         }
+
         void close() override {
             driveAndHold(LOW);
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::OPEN;
+        }
+
         String describe() override {
             return "normally open with switch duration " + String((int) switchDuration.count()) + "ms and hold duty " + String(holdDuty * 100) + "%";
         }
@@ -114,11 +128,17 @@ public:
             delay(switchDuration.count());
             controller.stop();
         }
+
         void close() override {
             controller.drive(LOW, 1.0);
             delay(switchDuration.count());
             controller.stop();
         }
+
+        ValveState getDefaultState() override {
+            return ValveState::NONE;
+        }
+
         String describe() override {
             return "latching with switch duration " + String((int) switchDuration.count()) + "ms";
         }
@@ -170,6 +190,10 @@ public:
 
     void close() override {
         strategy->close();
+    }
+
+    ValveState getDefaultState() override {
+        return strategy->getDefaultState();
     }
 
     void reset() override {


### PR DESCRIPTION
We only deactivated the override when a schedule was set. Now we return to a default state according to the valve's strategy, unless there is a schedule.